### PR TITLE
Evitar autodescargas con bots

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -9,7 +9,7 @@
     {{ params.clave1 }}
     {{ params.clave2 }}
     <div class="entry">
-        <audio controls="">
+        <audio controls="" preload="none">
             {% if endswith(post.filename, "m4a") -%}
             <source src="https://{{ params.op3 | safe }}/archive.org/download/{{post.identifier | safe}}/{{post.filename | safe}}" type="audio/m4a" />
             {% else -%}


### PR DESCRIPTION
Los mandamientos del podcasting recomiendan que no se descargue el audio cada vez que se pide la página -> preload="none"

Según discusiones de gente que entiende el preload="metadata" no funciona realmente, aunque sería el mal menor para evitar falsos positivos en las estadísticas y un desperdicio de ancho de banda / energía.